### PR TITLE
Fix translation configuration

### DIFF
--- a/configs/module.ini
+++ b/configs/module.ini
@@ -7,14 +7,13 @@
 ;resources.view.helperPath.Manual_View_Helper = '/var/www/tiger-www/application/modules/manual/views/helpers/'
 ;resources.view.helperPath.Manual_View_Helper = "Manual/View/Helper"
 ;resources.view.helperPathPrefix.Manual_View_Helper = "Manual_View_Helper"
-
-
-[staging : production]
 manual.translate.default_language = 'en'
 manual.translate.languages[] = 'en'
 manual.translate.languages[] = 'es'
 manual.translate.languages[] = 'fr'
 manual.translate.languages[] = 'pt'
+
+[staging : production]
 
 [testing : production]
 

--- a/configs/module.ini
+++ b/configs/module.ini
@@ -10,7 +10,11 @@
 
 
 [staging : production]
-
+manual.translate.default_language = 'en'
+manual.translate.languages[] = 'en'
+manual.translate.languages[] = 'es'
+manual.translate.languages[] = 'fr'
+manual.translate.languages[] = 'pt'
 
 [testing : production]
 

--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -6,7 +6,7 @@ class Manual_IndexController extends Tiger_Controller_Action
     {
         parent::init();
 
-        /** The CMS Controller should not be on hight ports 8080 and 8081 since these are usually public-facing pages. */
+        /** The CMS Controller should not be on high ports 8080 and 8081 since these are usually public-facing pages. */
         if ( in_array( $_SERVER['SERVER_PORT'], [ '8080', '8081' ] ) ) {
             $uri = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
             $this->redirect( $uri );
@@ -30,6 +30,8 @@ class Manual_IndexController extends Tiger_Controller_Action
         $this->view->inlineScript()->appendFile( Tiger_Cache::version('/assets/manual/js/manual.js') );
 
         $this->view->addHelperPath(MODULES_PATH . '/manual/views/helpers', 'Manual_View_Helper');
+
+		$this->view->lang = Manual_Service_Manual::getDocLang();
 
     }
 

--- a/layouts/scripts/layout.phtml
+++ b/layouts/scripts/layout.phtml
@@ -1,5 +1,5 @@
 <!doctype html>
-<html dir="ltr" lang="<?php echo LANG; ?>">
+<html dir="ltr" lang="<?php echo $this->lang; ?>">
     <head>
 
         <!-- Head Meta -->

--- a/services/Manual.php
+++ b/services/Manual.php
@@ -2,10 +2,24 @@
 
 class Manual_Service_Manual
 {
-
-    public function __construct() {
-    }
-
-
-
+	public function __construct() {
+	}
+	
+	public static function getDocLang()
+	{
+		$config = Zend_Registry::get('Zend_Config');
+		
+		if(!defined('LANG'))
+		{
+			define('LANG', 'en');
+		}
+		
+		if(!in_array(LANG, $config->manual->translate->languages))
+		{
+			return $config->manual->translate->default_language;
+		}
+		
+		return LANG;
+	}
+	
 }

--- a/views/helpers/Article.php
+++ b/views/helpers/Article.php
@@ -13,7 +13,7 @@ class Manual_View_Helper_Article extends Zend_View_Helper_Abstract
         $content = '';
 
         $article = Zend_Controller_Front::getInstance()->getRequest()->getParam('article');
-        $file = MODULES_PATH . '/manual/docs/' . LANG . '/' . $article;
+        $file = MODULES_PATH . '/manual/docs/' . Manual_Service_Manual::getDocLang() . '/' . $article;
 
         if ( file_exists( $file ) ) {
 

--- a/views/helpers/MainNav.php
+++ b/views/helpers/MainNav.php
@@ -6,7 +6,7 @@ class Manual_View_Helper_MainNav extends Zend_View_Helper_Abstract
     {
 
         $dom = new DOMDocument();
-        $dom->loadHTMLFile(MODULES_PATH . '/manual/docs/' . LANG . '/index.html');
+        $dom->loadHTMLFile(MODULES_PATH . '/manual/docs/' . Manual_Service_Manual::getDocLang() . '/index.html');
         $xpath = new DOMXpath( $dom );
         $toc = $xpath->query("//div[contains(@class,'toc')]");
 

--- a/views/helpers/SubNav.php
+++ b/views/helpers/SubNav.php
@@ -7,7 +7,7 @@ class Manual_View_Helper_SubNav extends Zend_View_Helper_Abstract
         $content = '';
 
         $article = Zend_Controller_Front::getInstance()->getRequest()->getParam('article');
-        $file = MODULES_PATH . '/manual/docs/' . LANG . '/' . $article;
+        $file = MODULES_PATH . '/manual/docs/' . Manual_Service_Manual::getDocLang() . '/' . $article;
 
         if ( file_exists( $file ) ) {
 


### PR DESCRIPTION
Moves manual.translate configuration from the staging block to the production block.

Unsupported languages are still throwing errors on https://zf1future.com/manual . Looking through the code, I noticed that I had initially added the configuration to the wrong section. I do not think that this will solve the problem, it looks like maybe the latest code it not deployed; I would expect it to fail in a different way.